### PR TITLE
Matches chrome version on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,6 @@ jobs:
 
       - name: Set up chromedriver
         uses: nanasess/setup-chromedriver@master
-        with:
-          chromedriver-version: '79.0.3945.36'
 
       - name: Check Versions
         run: |


### PR DESCRIPTION
Broken CI because chromedriver's version doesn't match google-chrome.
https://github.com/two-pack/redmine_xlsx_format_issue_exporter/commit/447daeab682fad69dd655a69c680d7a333dda776/checks?check_suite_id=396598717

This request remove version specified from nanasess/setup-chromedriver action.