### PR TITLE
Fix that spent time report XLSX shows translation missing text if custom fields are involved

### DIFF
--- a/lib/redmine_xlsx_format_issue_exporter/xlsx_report_helper.rb
+++ b/lib/redmine_xlsx_format_issue_exporter/xlsx_report_helper.rb
@@ -13,7 +13,7 @@ module RedmineXlsxFormatIssueExporter
       columns_width = []
 
       # Column headers
-      headers = report.criteria.collect {|criteria| l(report.available_criteria[criteria][:label]) }
+      headers = report.criteria.collect {|criteria| l_or_humanize(report.available_criteria[criteria][:label]) }
       start_period_index = headers.count
       worksheet.freeze_panes(1, start_period_index)  # Freeze header row and criteria column.
       headers += report.periods


### PR DESCRIPTION
Fix that spent time report XLSX shows translation missing text if custom fields are involved.
This problem is same of [the issue on Redmine.org](https://www.redmine.org/issues/32500).