### PR TITLE
Support Redmine5.0

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -9,19 +9,14 @@ Redmine::Plugin.register :redmine_xlsx_format_issue_exporter do
 end
 
 require_dependency 'queries_helper'
-require_dependency 'redmine_xlsx_format_issue_exporter/xlsx_export_helper'
-require_dependency 'redmine_xlsx_format_issue_exporter/xlsx_report_helper'
-require_dependency 'redmine_xlsx_format_issue_exporter/xlsx_users_helper'
+require_dependency 'query'
+require_dependency 'issues_controller'
+require_dependency 'timelog_controller'
+require_dependency 'users_controller'
+require_dependency 'projects_controller'
+Dir[File.dirname(__FILE__) + '/lib/redmine_xlsx_format_issue_exporter/*.rb'].sort.each {|file|  require file }
 
-require_dependency 'redmine_xlsx_format_issue_exporter/other_formats_builder'
-require_dependency 'redmine_xlsx_format_issue_exporter/view_layouts_base_body_bottom_hook'
-
-Rails.configuration.to_prepare do
-  require_dependency 'issues_controller'
-  require_dependency 'timelog_controller'
-  require_dependency 'users_controller'
-  require_dependency 'projects_controller'
-
+def prepend_xlsx_format_issue_exporter_patches
   unless IssuesController.included_modules.include? RedmineXlsxFormatIssueExporter::IssuesControllerPatch
     IssuesController.send(:prepend, RedmineXlsxFormatIssueExporter::IssuesControllerPatch)
   end
@@ -36,5 +31,13 @@ Rails.configuration.to_prepare do
 
   unless ProjectsController.included_modules.include?(RedmineXlsxFormatIssueExporter::ProjectsControllerPatch)
     ProjectsController.send(:prepend, RedmineXlsxFormatIssueExporter::ProjectsControllerPatch)
-    end
+  end
+end
+
+if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
+  prepend_xlsx_format_issue_exporter_patches
+else
+  Rails.configuration.to_prepare do
+    prepend_xlsx_format_issue_exporter_patches
+  end
 end

--- a/lib/redmine_xlsx_format_issue_exporter/view_layouts_base_body_bottom_hook.rb
+++ b/lib/redmine_xlsx_format_issue_exporter/view_layouts_base_body_bottom_hook.rb
@@ -1,5 +1,5 @@
 module RedmineXlsxFormatIssueExporter
-  class ViewLayoutsBaseBodyBootomHook < Redmine::Hook::ViewListener
+  class ViewLayoutsBaseBodyBottomHook < Redmine::Hook::ViewListener
 
     def view_layouts_base_body_bottom(context={})
       return unless context[:controller].status == 200


### PR DESCRIPTION
I made changes to support Zeitwerk with reference to https://zenn.dev/tohosaku/articles/3ccdeb2f38bb07 and https://zenn.dev/onozaty/articles/redmine5-plugin-migration .

Changes:
* Change the "require" file to an absolute path
* After supporting Zeitwerk, change to not use Rails.configuration.to_prepare
* Fix a class name that does not match the file name due to a typo (ViewLayoutsBaseBodyBottomHook)

I have confirmed that this change can start Redmine 5.0 and Redmine 4.2.
However, I don't have an Excel license so I can't test it enough.  I would like someone to verify the operation of the plugin features.

Thank you.